### PR TITLE
Add Python validation foundation

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -1,0 +1,33 @@
+name: Python Validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Test Python scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
-![Platform: PowerShell](https://img.shields.io/badge/Platform-PowerShell-blue)
+![Platform: Python](https://img.shields.io/badge/Platform-Python-blue)
 ![Status: Active](https://img.shields.io/badge/Status-Active-success)
 
 A hands-on workspace for exploring the intersection of **AI engineering**, **prompt design**, **machine learning**, and **AI ethics**.  
@@ -79,6 +79,33 @@ pip install -r requirements.txt
 
 # Launch JupyterLab
 jupyter lab
+```
+
+Run the command-line experiments directly:
+
+```bash
+# Generate prompt variants from the sample topic list
+python scripts/generate_prompts.py \
+  --input datasets/sample_prompts.csv \
+  --output outputs/generated_prompts.json \
+  --with-metadata \
+  --dedupe
+
+# Train the sample sentiment model
+python scripts/train_model.py \
+  --data datasets/sentiment_training.json \
+  --model outputs/sentiment_model.joblib \
+  --summary outputs/sentiment_model_summary.json
+```
+
+## ✅ Validation
+
+Run the built-in test suite before changing scripts:
+
+```bash
+pip install -r requirements-test.txt
+python -m unittest discover -s tests -v
+```
 
 ---
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+numpy
+pandas
+scikit-learn

--- a/tests/test_bias_detection.py
+++ b/tests/test_bias_detection.py
@@ -1,0 +1,37 @@
+import unittest
+
+from scripts import bias_detection
+
+
+class BiasDetectionTests(unittest.TestCase):
+    def test_compile_patterns_matches_terms_case_insensitively(self):
+        patterns = bias_detection.compile_patterns({"pregnant": ("gender", 1.0)})
+
+        hits = bias_detection.extract_hits("Pregnant candidate", patterns)
+
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["category"], "gender")
+
+    def test_allowlist_suppresses_matching_terms(self):
+        patterns = bias_detection.compile_patterns({"male": ("gender", 0.5)})
+
+        hits = bias_detection.extract_hits(
+            "male candidate",
+            patterns,
+            whitelist=["male"],
+        )
+
+        self.assertEqual(hits, [])
+
+    def test_score_row_caps_category_totals(self):
+        score, per_category = bias_detection.score_row(
+            [
+                {"category": "gender", "weight": 2.0},
+                {"category": "gender", "weight": 2.0},
+                {"category": "age", "weight": 1.0},
+            ],
+            category_caps={"gender": 3.0, "age": 3.0},
+        )
+
+        self.assertEqual(score, 4.0)
+        self.assertEqual(per_category["gender"], 4.0)

--- a/tests/test_generate_prompts.py
+++ b/tests/test_generate_prompts.py
@@ -1,0 +1,44 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import generate_prompts
+
+
+class GeneratePromptsTests(unittest.TestCase):
+    def test_load_templates_accepts_json_list(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = Path(tmp_dir) / "templates.json"
+            config_path.write_text('["Explain {topic}."]', encoding="utf-8")
+
+            templates = generate_prompts.load_templates(str(config_path))
+
+        self.assertEqual(templates, ["Explain {topic}."])
+
+    def test_fill_template_uses_defaults_for_optional_fields(self):
+        prompt = generate_prompts.fill_template(
+            "Explain {topic} to a {audience} in a {style} style for {domain}.",
+            {"topic": "prompt engineering"},
+        )
+
+        self.assertEqual(
+            prompt,
+            "Explain prompt engineering to a general reader in a concise style for general.",
+        )
+
+    def test_build_permutations_skips_blank_topics(self):
+        permutations = list(
+            generate_prompts.build_permutations(
+                {"topic": "   "},
+                styles=["concise"],
+                audiences=["engineer"],
+                levels=["easy"],
+            )
+        )
+
+        self.assertEqual(permutations, [])
+
+    def test_dedupe_keep_order_preserves_first_seen_value(self):
+        values = generate_prompts.dedupe_keep_order(["a", "b", "a", "c", "b"])
+
+        self.assertEqual(values, ["a", "b", "c"])

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -1,0 +1,34 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import train_model
+
+
+class TrainModelTests(unittest.TestCase):
+    def test_load_json_dataset_reads_standard_payload(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data_path = Path(tmp_dir) / "dataset.json"
+            data_path.write_text(
+                json.dumps({"text": ["good", "bad"], "label": [1, 0]}),
+                encoding="utf-8",
+            )
+
+            frame = train_model.load_json_dataset(data_path)
+
+        self.assertEqual(frame["text"].tolist(), ["good", "bad"])
+        self.assertEqual(frame["label"].tolist(), [1, 0])
+
+    def test_load_json_dataset_renames_prompt_column_for_jsonl(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data_path = Path(tmp_dir) / "dataset.jsonl"
+            data_path.write_text(
+                '{"prompt":"good","label":1}\n{"prompt":"bad","label":0}\n',
+                encoding="utf-8",
+            )
+
+            frame = train_model.load_json_dataset(data_path)
+
+        self.assertEqual(frame["text"].tolist(), ["good", "bad"])
+        self.assertEqual(frame["label"].tolist(), [1, 0])


### PR DESCRIPTION
## Summary
- add a lightweight unit-test suite for the prompt, bias, and training helpers
- add GitHub Actions validation using a focused test dependency set
- fix the README quickstart fence, correct the platform badge, and document direct CLI usage

## Verification
- python3 -m unittest discover -s tests -v