### PR TITLE
Add guided lab walkthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ datasets/*.bak
 
 # Allow small sample files
 !datasets/sample_prompts.csv
+!datasets/sample_bias_texts.csv
 !datasets/sentiment_training.json
 
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ python scripts/train_model.py \
   --summary outputs/sentiment_model_summary.json
 ```
 
+For one compact path through prompt generation, bias review, and sentiment training, see [docs/lab_walkthrough.md](docs/lab_walkthrough.md).
+
 ## ✅ Validation
 
 Run the built-in test suite before changing scripts:

--- a/datasets/sample_bias_texts.csv
+++ b/datasets/sample_bias_texts.csv
@@ -1,0 +1,9 @@
+id,group,text
+1,screening,"Candidate has strong Python experience and clear project ownership."
+2,screening,"Pregnant candidate may need schedule flexibility during onboarding."
+3,screening,"Applicant is too young for the leadership expectations of this role."
+4,screening,"Candidate documented reliable delivery and strong stakeholder communication."
+5,appeals,"Customer asked whether religion-related holidays can be accommodated."
+6,appeals,"Ticket notes mention disability support needs for the service workflow."
+7,appeals,"Customer provided complete documentation and a clear reproduction path."
+8,appeals,"Reviewer referenced nationality when discussing escalation priority."

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -1,0 +1,76 @@
+# Guided Lab Walkthrough
+
+This walkthrough gives the repository one compact, no-API path from prompt generation to responsible-AI review to classical model training.
+
+## 1. Generate Prompt Variants
+
+Create structured prompt examples from the sample topic list:
+
+```bash
+python scripts/generate_prompts.py \
+  --input datasets/sample_prompts.csv \
+  --output outputs/generated_prompts.json \
+  --with-metadata \
+  --dedupe \
+  --seed 42
+```
+
+Expected result:
+
+- `outputs/generated_prompts.json`
+- `20` prompt records per topic by default after the per-topic cap
+
+## 2. Run A Bias Review
+
+Use the sanitized sample review text to exercise the lexical bias detector:
+
+```bash
+python scripts/bias_detection.py \
+  --data datasets/sample_bias_texts.csv \
+  --text-col text \
+  --id-col id \
+  --group-col group \
+  --output-base outputs/sample_bias_report
+```
+
+Expected result:
+
+- `outputs/sample_bias_report.json`
+- `outputs/sample_bias_report.csv`
+- `outputs/sample_bias_report.md`
+- flagged terms across age, gender, religion, disability, and nationality examples
+
+The sample rows are intentionally synthetic and compact. They are meant to demonstrate the review workflow, not to stand in for a production fairness dataset.
+
+## 3. Train The Sentiment Baseline
+
+Train the sample TF-IDF + Logistic Regression classifier:
+
+```bash
+python scripts/train_model.py \
+  --data datasets/sentiment_training.json \
+  --model outputs/sentiment_model.joblib \
+  --summary outputs/sentiment_model_summary.json \
+  --seed 42
+```
+
+Expected result:
+
+- `outputs/sentiment_model.joblib`
+- `outputs/sentiment_model_summary.json`
+
+## 4. Validate The Repo
+
+Run the lightweight regression suite before changing scripts:
+
+```bash
+pip install -r requirements-test.txt
+python -m unittest discover -s tests -v
+```
+
+## What This Demonstrates
+
+- prompt generation with deterministic examples
+- responsible-AI review with traceable flagged rows and group metrics
+- a reproducible baseline training run with saved artifacts
+- a small local validation loop suitable for pull requests

--- a/scripts/bias_detection.py
+++ b/scripts/bias_detection.py
@@ -22,7 +22,7 @@ Examples
 import argparse, json, re, sys, os
 from pathlib import Path
 from collections import Counter, defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -158,6 +158,14 @@ def score_row(hits, category_caps=None):
 def safe_mkdir(path: Path):
     path.parent.mkdir(parents=True, exist_ok=True)
 
+def to_json_scalar(value):
+    """Convert pandas/numpy scalar values into JSON-friendly Python values."""
+    if pd.isna(value):
+        return None
+    if hasattr(value, "item"):
+        return value.item()
+    return value
+
 # ------------------------- Main -------------------------
 def main():
     ap = argparse.ArgumentParser(description="Lexical bias signal detector with reporting.")
@@ -219,7 +227,7 @@ def main():
 
         row_obj = {
             "index": int(idx),
-            "id": df[args.id_col].iloc[idx] if args.id_col and args.id_col in df.columns else None,
+            "id": to_json_scalar(df[args.id_col].iloc[idx]) if args.id_col and args.id_col in df.columns else None,
             "text": text,
             "score": score,
             "per_category": per_cat,
@@ -247,7 +255,7 @@ def main():
             f = int(flagged_by_group.get(grp, 0))
             rate = float(f) / float(total) if total else 0.0
             group_stats.append({
-                "group": None if pd.isna(grp) else grp,
+                "group": to_json_scalar(grp),
                 "total": int(total),
                 "flagged": int(f),
                 "flag_rate": round(rate, 4)
@@ -255,7 +263,7 @@ def main():
 
     # Build summary
     summary = {
-        "generated_at_utc": datetime.utcnow().isoformat() + "Z",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "source_csv": str(Path(args.data).resolve()),
         "rows": int(len(df)),
         "text_col": args.text_col,

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -150,7 +150,7 @@ def main(data_path, model_path, summary_path, test_size, val_size, seed, ngram_m
     run_id = str(uuid.uuid4())
     summary = {
         "run_id": run_id,
-        "timestamp_utc": pd.Timestamp.utcnow().isoformat() + "Z",
+        "timestamp_utc": pd.Timestamp.now(tz="UTC").isoformat().replace("+00:00", "Z"),
         "data_path": str(data_path),
         "rows": int(len(df)),
         "class_dist": {int(k): int(v) for k, v in pd.Series(y).value_counts().to_dict().items()},

--- a/tests/test_bias_detection.py
+++ b/tests/test_bias_detection.py
@@ -35,3 +35,13 @@ class BiasDetectionTests(unittest.TestCase):
 
         self.assertEqual(score, 4.0)
         self.assertEqual(per_category["gender"], 4.0)
+
+    def test_sample_bias_dataset_is_available_for_walkthrough(self):
+        sample_path = bias_detection.Path("datasets/sample_bias_texts.csv")
+
+        self.assertTrue(sample_path.exists())
+
+    def test_to_json_scalar_converts_numpy_backed_values(self):
+        import numpy as np
+
+        self.assertEqual(bias_detection.to_json_scalar(np.int64(7)), 7)


### PR DESCRIPTION
## Summary
- add a synthetic sample dataset for the bias-detection workflow
- add a guided walkthrough that links prompt generation, bias review, training, and validation
- fix bias-report JSON serialization for pandas-backed scalar IDs and use timezone-aware timestamps

## Verification
- python3 scripts/generate_prompts.py --input datasets/sample_prompts.csv --output outputs/generated_prompts.json --with-metadata --dedupe --seed 42
- python3 scripts/bias_detection.py --data datasets/sample_bias_texts.csv --text-col text --id-col id --group-col group --output-base outputs/sample_bias_report
- python3 scripts/train_model.py --data datasets/sentiment_training.json --model outputs/sentiment_model.joblib --summary outputs/sentiment_model_summary.json --seed 42
- python3 -m unittest discover -s tests -v