### PR TITLE
Document and harden sentiment baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ python scripts/train_model.py \
 ```
 
 For one compact path through prompt generation, bias review, and sentiment training, see [docs/lab_walkthrough.md](docs/lab_walkthrough.md).
+For the training data contract, run metadata, and baseline limitations, see [docs/model_baseline.md](docs/model_baseline.md).
 
 ## ✅ Validation
 

--- a/docs/model_baseline.md
+++ b/docs/model_baseline.md
@@ -1,0 +1,59 @@
+# Sentiment Baseline
+
+The repository includes a small classical baseline in `scripts/train_model.py`:
+
+- TF-IDF text features
+- Logistic Regression classifier
+- stratified train/test splitting
+- JSON summary output with metrics and artifact paths
+
+## Purpose
+
+This baseline is intentionally simple. It is useful for demonstrating:
+
+- how to load a text classification dataset
+- how to record a reproducible training run
+- how to compare later experiments against a known starting point
+
+It is not intended to represent production-grade sentiment modeling or state-of-the-art performance.
+
+## Dataset Contract
+
+The input dataset must contain:
+
+- `text`: free-text examples
+- `label`: binary labels using `0` and `1`
+
+The training script validates that both classes are present and that each class has at least two rows before it attempts stratified splitting.
+
+The sample dataset in `datasets/sentiment_training.json` is intentionally tiny and synthetic. Its role is to exercise the workflow, not to produce a strong model.
+
+## Reproducibility
+
+Each summary JSON records:
+
+- a generated `run_id`
+- `timestamp_utc`
+- the source `data_path`
+- `data_sha256`
+- class distribution and split sizes
+- selected parameters
+- test metrics and confusion matrix
+
+Run the baseline with a fixed seed:
+
+```bash
+python scripts/train_model.py \
+  --data datasets/sentiment_training.json \
+  --model outputs/sentiment_model.joblib \
+  --summary outputs/sentiment_model_summary.json \
+  --seed 42
+```
+
+## Interpreting Results
+
+Because the bundled dataset is deliberately small, metrics may look weak or unstable. Treat the output as a workflow demonstration:
+
+- confirm the training path runs
+- inspect the saved summary
+- use the baseline as a comparison point for richer datasets or later models

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -21,7 +21,7 @@ Examples:
     --search --ngram-max 2 --min-df 2 --class-weight balanced --seed 42
 """
 
-import argparse, json, os, sys, uuid
+import argparse, hashlib, json, os, sys, uuid
 from pathlib import Path
 
 import numpy as np
@@ -49,6 +49,32 @@ def load_json_dataset(path: Path, jsonl: bool = False):
         return pd.DataFrame({"text": payload["text"], "label": payload["label"]})
     raise ValueError("Unsupported JSON format. Expect keys: 'text' and 'label'.")
 
+def validate_dataset(df: pd.DataFrame):
+    """Validate the minimum contract needed for stratified binary classification."""
+    missing = {"text", "label"} - set(df.columns)
+    if missing:
+        raise ValueError(f"Dataset is missing required column(s): {', '.join(sorted(missing))}.")
+
+    cleaned = df.dropna(subset=["text", "label"]).copy()
+    cleaned["text"] = cleaned["text"].astype(str)
+    cleaned["label"] = cleaned["label"].astype(int)
+
+    if cleaned.empty:
+        raise ValueError("Dataset contains no usable rows after dropping missing text/label values.")
+
+    labels = sorted(cleaned["label"].unique().tolist())
+    if labels != [0, 1]:
+        raise ValueError("Dataset must contain binary labels 0 and 1.")
+
+    class_counts = cleaned["label"].value_counts().to_dict()
+    if min(class_counts.values()) < 2:
+        raise ValueError("Each class must contain at least 2 rows for stratified splitting.")
+
+    return cleaned
+
+def sha256_file(path: Path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
 
 def main(data_path, model_path, summary_path, test_size, val_size, seed, ngram_max,
          min_df, max_features, class_weight, C, penalty, solver, lowercase, stop_words,
@@ -60,9 +86,7 @@ def main(data_path, model_path, summary_path, test_size, val_size, seed, ngram_m
         sys.exit(f"Data not found: {data_path}")
 
     # Load
-    df = load_json_dataset(data_path, jsonl=False)
-    df = df.dropna(subset=["text", "label"])
-    df["text"] = df["text"].astype(str)
+    df = validate_dataset(load_json_dataset(data_path, jsonl=False))
     y = df["label"].astype(int).values
     X = df["text"].values
 
@@ -152,6 +176,7 @@ def main(data_path, model_path, summary_path, test_size, val_size, seed, ngram_m
         "run_id": run_id,
         "timestamp_utc": pd.Timestamp.now(tz="UTC").isoformat().replace("+00:00", "Z"),
         "data_path": str(data_path),
+        "data_sha256": sha256_file(data_path),
         "rows": int(len(df)),
         "class_dist": {int(k): int(v) for k, v in pd.Series(y).value_counts().to_dict().items()},
         "splits": {

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -32,3 +32,31 @@ class TrainModelTests(unittest.TestCase):
 
         self.assertEqual(frame["text"].tolist(), ["good", "bad"])
         self.assertEqual(frame["label"].tolist(), [1, 0])
+
+    def test_validate_dataset_rejects_non_binary_labels(self):
+        frame = train_model.pd.DataFrame(
+            {"text": ["a", "b", "c"], "label": [0, 1, 2]}
+        )
+
+        with self.assertRaisesRegex(ValueError, "binary labels 0 and 1"):
+            train_model.validate_dataset(frame)
+
+    def test_validate_dataset_requires_two_rows_per_class(self):
+        frame = train_model.pd.DataFrame(
+            {"text": ["good", "bad", "great"], "label": [1, 0, 1]}
+        )
+
+        with self.assertRaisesRegex(ValueError, "at least 2 rows"):
+            train_model.validate_dataset(frame)
+
+    def test_sha256_file_returns_stable_digest(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data_path = Path(tmp_dir) / "dataset.json"
+            data_path.write_text('{"text":["good","bad"],"label":[1,0]}', encoding="utf-8")
+
+            digest = train_model.sha256_file(data_path)
+
+        self.assertEqual(
+            digest,
+            "2e2610caa83cc8019f9a433bdfe01c8bb8b7c8e0116a2516f834e37bb98f30f8",
+        )


### PR DESCRIPTION
## Summary
- validate sentiment datasets before stratified training begins
- record the source dataset SHA-256 in each run summary for reproducibility
- add baseline documentation covering purpose, data contract, and interpretation

## Verification
- python3 -m unittest discover -s tests -v
- python3 scripts/train_model.py --data datasets/sentiment_training.json --model outputs/sentiment_model.joblib --summary outputs/sentiment_model_summary.json --seed 42