### PR TITLE
Add prompt evaluation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ python scripts/train_model.py \
 ```
 
 For one compact path through prompt generation, bias review, and sentiment training, see [docs/lab_walkthrough.md](docs/lab_walkthrough.md).
+For prompt-batch scoring guidance, see [docs/prompt_evaluation.md](docs/prompt_evaluation.md).
 For the training data contract, run metadata, and baseline limitations, see [docs/model_baseline.md](docs/model_baseline.md).
 
 ## ✅ Validation

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -20,7 +20,22 @@ Expected result:
 - `outputs/generated_prompts.json`
 - `20` prompt records per topic by default after the per-topic cap
 
-## 2. Run A Bias Review
+## 2. Evaluate Prompt Quality
+
+Score the generated prompt batch before moving to downstream experiments:
+
+```bash
+python scripts/evaluate_prompts.py \
+  --input outputs/generated_prompts.json \
+  --output-base outputs/prompt_evaluation
+```
+
+Expected result:
+
+- `outputs/prompt_evaluation.json`
+- `outputs/prompt_evaluation.md`
+
+## 3. Run A Bias Review
 
 Use the sanitized sample review text to exercise the lexical bias detector:
 
@@ -42,7 +57,7 @@ Expected result:
 
 The sample rows are intentionally synthetic and compact. They are meant to demonstrate the review workflow, not to stand in for a production fairness dataset.
 
-## 3. Train The Sentiment Baseline
+## 4. Train The Sentiment Baseline
 
 Train the sample TF-IDF + Logistic Regression classifier:
 
@@ -59,7 +74,7 @@ Expected result:
 - `outputs/sentiment_model.joblib`
 - `outputs/sentiment_model_summary.json`
 
-## 4. Validate The Repo
+## 5. Validate The Repo
 
 Run the lightweight regression suite before changing scripts:
 
@@ -71,6 +86,7 @@ python -m unittest discover -s tests -v
 ## What This Demonstrates
 
 - prompt generation with deterministic examples
+- prompt comparison with a transparent deterministic rubric
 - responsible-AI review with traceable flagged rows and group metrics
 - a reproducible baseline training run with saved artifacts
 - a small local validation loop suitable for pull requests

--- a/docs/prompt_evaluation.md
+++ b/docs/prompt_evaluation.md
@@ -1,0 +1,54 @@
+# Prompt Evaluation
+
+`scripts/evaluate_prompts.py` provides a transparent, deterministic rubric for generated prompt batches.
+
+## What It Scores
+
+Each prompt receives one point for:
+
+- specificity
+- structure
+- audience targeting
+- evaluation readiness
+
+Grades are:
+
+- `strong`: score `3-4`
+- `usable`: score `2`
+- `thin`: score `0-1`
+
+The rubric is intentionally simple. It is meant for quick local comparison before introducing model calls, human review, or richer evaluation systems.
+
+## Example Workflow
+
+Generate a prompt batch:
+
+```bash
+python scripts/generate_prompts.py \
+  --input datasets/sample_prompts.csv \
+  --output outputs/generated_prompts.json \
+  --with-metadata \
+  --dedupe \
+  --seed 42
+```
+
+Score it:
+
+```bash
+python scripts/evaluate_prompts.py \
+  --input outputs/generated_prompts.json \
+  --output-base outputs/prompt_evaluation
+```
+
+Outputs:
+
+- `outputs/prompt_evaluation.json`
+- `outputs/prompt_evaluation.md`
+
+## How To Use It
+
+- compare batches after changing templates
+- spot prompt families that are consistently thin
+- keep prompt experiments reviewable before involving an LLM API
+
+This is a heuristic quality screen, not a substitute for task-grounded evaluation against real model outputs.

--- a/scripts/evaluate_prompts.py
+++ b/scripts/evaluate_prompts.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Evaluate generated prompts with a deterministic lightweight rubric.
+
+The scorer is intentionally simple and transparent. It is useful for comparing
+prompt batches before any model API call is introduced.
+"""
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+
+STRUCTURE_TERMS = ("checklist", "bullets", "sections", "outline", "matrix", "step-by-step")
+EVALUATION_TERMS = ("criteria", "metrics", "assessment", "risks", "pitfalls", "mitigations")
+
+
+def load_prompt_records(path: Path):
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError("Prompt input must be a JSON array.")
+
+    records = []
+    for item in payload:
+        if isinstance(item, str):
+            records.append({"prompt": item})
+        elif isinstance(item, dict) and isinstance(item.get("prompt"), str):
+            records.append(item)
+        else:
+            raise ValueError("Each prompt item must be a string or object with a string 'prompt'.")
+    return records
+
+
+def score_prompt(record: dict):
+    prompt = record["prompt"]
+    lower = prompt.lower()
+    dimensions = {
+        "specificity": int(any(token in lower for token in ("exactly", "include", "with constraints", "vs alternatives"))),
+        "structure": int(any(token in lower for token in STRUCTURE_TERMS)),
+        "audience": int(bool(record.get("audience")) or "for a " in lower or "aimed at a " in lower),
+        "evaluation_ready": int(any(token in lower for token in EVALUATION_TERMS)),
+    }
+    total = sum(dimensions.values())
+    return {
+        **record,
+        "rubric": dimensions,
+        "score": total,
+        "grade": "strong" if total >= 3 else "usable" if total >= 2 else "thin",
+    }
+
+
+def summarize(scored_records):
+    by_grade = Counter(record["grade"] for record in scored_records)
+    avg_score = round(sum(record["score"] for record in scored_records) / max(1, len(scored_records)), 3)
+    return {
+        "records": len(scored_records),
+        "average_score": avg_score,
+        "grades": dict(sorted(by_grade.items())),
+        "top_prompts": [
+            {
+                "topic": record.get("topic"),
+                "prompt": record["prompt"],
+                "score": record["score"],
+                "grade": record["grade"],
+            }
+            for record in sorted(scored_records, key=lambda row: (-row["score"], row["prompt"]))[:5]
+        ],
+    }
+
+
+def write_markdown(path: Path, summary: dict):
+    lines = [
+        "# Prompt Evaluation Report",
+        "",
+        f"- Records: `{summary['records']}`",
+        f"- Average score: `{summary['average_score']}`",
+        "",
+        "## Grade Distribution",
+        "",
+        "| Grade | Count |",
+        "|---|---:|",
+    ]
+    for grade, count in summary["grades"].items():
+        lines.append(f"| {grade} | {count} |")
+
+    lines += ["", "## Top Prompts", ""]
+    for record in summary["top_prompts"]:
+        topic = record["topic"] or "Unlabeled"
+        lines.append(f"- **{topic}** (`{record['score']}` / {record['grade']}): {record['prompt']}")
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Score generated prompts with a deterministic rubric.")
+    parser.add_argument("--input", required=True, help="JSON array from generate_prompts.py")
+    parser.add_argument("--output-base", default="outputs/prompt_evaluation", help="Base path for JSON and Markdown outputs")
+    args = parser.parse_args()
+
+    records = load_prompt_records(Path(args.input))
+    scored = [score_prompt(record) for record in records]
+    summary = summarize(scored)
+
+    base = Path(args.output_base)
+    base.parent.mkdir(parents=True, exist_ok=True)
+    base.with_suffix(".json").write_text(
+        json.dumps({"summary": summary, "records": scored}, indent=2),
+        encoding="utf-8",
+    )
+    write_markdown(base.with_suffix(".md"), summary)
+
+    print(f"Wrote JSON -> {base.with_suffix('.json')}")
+    print(f"Wrote Markdown -> {base.with_suffix('.md')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evaluate_prompts.py
+++ b/tests/test_evaluate_prompts.py
@@ -1,0 +1,45 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import evaluate_prompts
+
+
+class EvaluatePromptsTests(unittest.TestCase):
+    def test_load_prompt_records_accepts_strings_and_metadata_objects(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            prompt_path = Path(tmp_dir) / "prompts.json"
+            prompt_path.write_text(
+                json.dumps(["Explain caching.", {"prompt": "Use exactly 5 bullets.", "topic": "Caching"}]),
+                encoding="utf-8",
+            )
+
+            records = evaluate_prompts.load_prompt_records(prompt_path)
+
+        self.assertEqual(records[0]["prompt"], "Explain caching.")
+        self.assertEqual(records[1]["topic"], "Caching")
+
+    def test_score_prompt_marks_structured_audience_targeted_prompts_strong(self):
+        scored = evaluate_prompts.score_prompt(
+            {
+                "prompt": "Create a step-by-step checklist. Include metrics for a junior dev.",
+                "audience": "junior dev",
+            }
+        )
+
+        self.assertEqual(scored["score"], 4)
+        self.assertEqual(scored["grade"], "strong")
+
+    def test_summarize_reports_grade_distribution(self):
+        summary = evaluate_prompts.summarize(
+            [
+                {"prompt": "a", "score": 4, "grade": "strong"},
+                {"prompt": "b", "score": 2, "grade": "usable"},
+                {"prompt": "c", "score": 1, "grade": "thin"},
+            ]
+        )
+
+        self.assertEqual(summary["records"], 3)
+        self.assertEqual(summary["average_score"], 2.333)
+        self.assertEqual(summary["grades"], {"strong": 1, "thin": 1, "usable": 1})


### PR DESCRIPTION
## Summary
- add a deterministic prompt scoring script with JSON and Markdown reports
- document the rubric and add it to the guided lab walkthrough
- add unit coverage for loading, scoring, and summarizing prompt batches

## Verification
- python3 scripts/generate_prompts.py --input datasets/sample_prompts.csv --output outputs/generated_prompts.json --with-metadata --dedupe --seed 42
- python3 scripts/evaluate_prompts.py --input outputs/generated_prompts.json --output-base outputs/prompt_evaluation
- python3 -m unittest discover -s tests -v