### PR TITLE
Validate lab workflow artifacts

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Run unit tests
         run: python -m unittest discover -s tests -v
+
+      - name: Run lab smoke test
+        run: python scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -18,6 +18,8 @@ Expected result:
 - sentiment baseline model and summary
 - `outputs/lab_run/manifest.json`
 
+The manifest records each step, captured command output, and whether every expected artifact was created.
+
 ## 1. Generate Prompt Variants
 
 Create structured prompt examples from the sample topic list:

--- a/scripts/run_lab_workflow.py
+++ b/scripts/run_lab_workflow.py
@@ -105,19 +105,42 @@ def run_step(step: dict, root: Path):
         text=True,
         capture_output=True,
     )
+    artifacts = validate_artifacts(step["artifacts"])
     return {
         "name": step["name"],
         "command": step["command"],
         "stdout": completed.stdout.strip(),
         "stderr": completed.stderr.strip(),
-        "artifacts": [str(path) for path in step["artifacts"]],
+        "artifacts": artifacts,
     }
+
+
+def validate_artifacts(paths: list[Path]):
+    artifacts = []
+    missing = []
+    for path in paths:
+        exists = path.exists()
+        artifacts.append(
+            {
+                "path": str(path),
+                "exists": exists,
+                "bytes": path.stat().st_size if exists and path.is_file() else 0,
+            }
+        )
+        if not exists:
+            missing.append(str(path))
+
+    if missing:
+        raise FileNotFoundError(f"Expected artifact(s) were not created: {', '.join(missing)}")
+
+    return artifacts
 
 
 def write_manifest(path: Path, results: list[dict]):
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "generated_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "status": "passed",
         "steps": results,
     }
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/tests/test_run_lab_workflow.py
+++ b/tests/test_run_lab_workflow.py
@@ -34,4 +34,23 @@ class RunLabWorkflowTests(unittest.TestCase):
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
 
         self.assertEqual(manifest["steps"][0]["name"], "generate_prompts")
+        self.assertEqual(manifest["status"], "passed")
         self.assertIn("generated_at_utc", manifest)
+
+    def test_validate_artifacts_reports_existing_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            artifact = Path(tmp_dir) / "artifact.json"
+            artifact.write_text("{}", encoding="utf-8")
+
+            artifacts = run_lab_workflow.validate_artifacts([artifact])
+
+        self.assertEqual(artifacts[0]["path"], str(artifact))
+        self.assertTrue(artifacts[0]["exists"])
+        self.assertGreater(artifacts[0]["bytes"], 0)
+
+    def test_validate_artifacts_fails_for_missing_files(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            missing = Path(tmp_dir) / "missing.json"
+
+            with self.assertRaisesRegex(FileNotFoundError, "Expected artifact"):
+                run_lab_workflow.validate_artifacts([missing])


### PR DESCRIPTION
## Summary
- have the lab runner verify each expected artifact exists and record file sizes in the manifest
- add a passed status to workflow manifests
- run the skip-training lab smoke test in CI after unit tests

## Verification
- python3 -m unittest discover -s tests -v
- python3 scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training