### PR TITLE
Add lab run summary report

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Run the command-line experiments directly:
 # Run the full no-API lab workflow
 python scripts/run_lab_workflow.py --output-dir outputs/lab_run
 
+# Summarize the completed run
+python scripts/summarize_lab_run.py \
+  --manifest outputs/lab_run/manifest.json \
+  --output outputs/lab_run/summary.md
+
 # Generate prompt variants from the sample topic list
 python scripts/generate_prompts.py \
   --input datasets/sample_prompts.csv \

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -20,6 +20,14 @@ Expected result:
 
 The manifest records each step, captured command output, and whether every expected artifact was created.
 
+Generate a readable summary from the completed run:
+
+```bash
+python scripts/summarize_lab_run.py \
+  --manifest outputs/lab_run/manifest.json \
+  --output outputs/lab_run/summary.md
+```
+
 ## 1. Generate Prompt Variants
 
 Create structured prompt examples from the sample topic list:

--- a/scripts/summarize_lab_run.py
+++ b/scripts/summarize_lab_run.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+Summarize a completed local lab run into a readable Markdown report.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json_if_exists(path: Path):
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def find_step(manifest: dict, name: str):
+    for step in manifest.get("steps", []):
+        if step.get("name") == name:
+            return step
+    return None
+
+
+def artifact_path(step: dict | None, suffix: str):
+    if not step:
+        return None
+    for artifact in step.get("artifacts", []):
+        path = artifact["path"] if isinstance(artifact, dict) else artifact
+        if path.endswith(suffix):
+            return Path(path)
+    return None
+
+
+def build_summary(manifest_path: Path):
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    base_dir = manifest_path.parent
+
+    prompt_eval = load_json_if_exists(
+        artifact_path(find_step(manifest, "evaluate_prompts"), "prompt_evaluation.json")
+        or base_dir / "prompt_evaluation.json"
+    )
+    bias_report = load_json_if_exists(
+        artifact_path(find_step(manifest, "bias_detection"), "sample_bias_report.json")
+        or base_dir / "sample_bias_report.json"
+    )
+    model_summary = load_json_if_exists(
+        artifact_path(find_step(manifest, "train_sentiment_baseline"), "sentiment_model_summary.json")
+        or base_dir / "sentiment_model_summary.json"
+    )
+
+    return {
+        "manifest": manifest,
+        "prompt_eval": prompt_eval,
+        "bias_report": bias_report,
+        "model_summary": model_summary,
+    }
+
+
+def render_markdown(summary: dict):
+    manifest = summary["manifest"]
+    lines = [
+        "# Lab Run Summary",
+        "",
+        f"- Status: `{manifest.get('status', 'unknown')}`",
+        f"- Generated: `{manifest.get('generated_at_utc', 'unknown')}`",
+        f"- Steps: `{len(manifest.get('steps', []))}`",
+        "",
+        "## Workflow Steps",
+        "",
+        "| Step | Artifacts |",
+        "|---|---:|",
+    ]
+
+    for step in manifest.get("steps", []):
+        lines.append(f"| {step.get('name')} | {len(step.get('artifacts', []))} |")
+
+    prompt_eval = summary["prompt_eval"]
+    if prompt_eval:
+        prompt_summary = prompt_eval["summary"]
+        lines += [
+            "",
+            "## Prompt Evaluation",
+            "",
+            f"- Records: `{prompt_summary['records']}`",
+            f"- Average score: `{prompt_summary['average_score']}`",
+            f"- Grades: `{prompt_summary['grades']}`",
+        ]
+
+    bias_report = summary["bias_report"]
+    if bias_report:
+        bias_summary = bias_report["summary"]
+        lines += [
+            "",
+            "## Bias Review",
+            "",
+            f"- Rows: `{bias_summary['rows']}`",
+            f"- Flagged: `{bias_summary['flagged_count']}`",
+            f"- Flagged rate: `{bias_summary['flagged_rate']}`",
+            f"- Categories present: `{', '.join(bias_summary['categories_present'])}`",
+        ]
+
+    model_summary = summary["model_summary"]
+    if model_summary:
+        test = model_summary["test"]
+        lines += [
+            "",
+            "## Sentiment Baseline",
+            "",
+            f"- Rows: `{model_summary['rows']}`",
+            f"- Data SHA-256: `{model_summary['data_sha256']}`",
+            f"- Test ROC-AUC: `{test['roc_auc']}`",
+            f"- Confusion matrix: `{test['confusion_matrix']}`",
+        ]
+    else:
+        lines += [
+            "",
+            "## Sentiment Baseline",
+            "",
+            "_Training was skipped for this lab run._",
+        ]
+
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Summarize a completed AI Engineering Lab run.")
+    parser.add_argument("--manifest", required=True, help="Path to a lab-run manifest JSON.")
+    parser.add_argument("--output", default=None, help="Markdown output path. Defaults next to manifest.")
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    output_path = Path(args.output) if args.output else manifest_path.with_name("summary.md")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_markdown(build_summary(manifest_path)), encoding="utf-8")
+    print(f"Lab summary written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_summarize_lab_run.py
+++ b/tests/test_summarize_lab_run.py
@@ -1,0 +1,56 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import summarize_lab_run
+
+
+class SummarizeLabRunTests(unittest.TestCase):
+    def test_render_markdown_handles_skipped_training(self):
+        markdown = summarize_lab_run.render_markdown(
+            {
+                "manifest": {
+                    "status": "passed",
+                    "generated_at_utc": "2026-01-01T00:00:00Z",
+                    "steps": [{"name": "generate_prompts", "artifacts": []}],
+                },
+                "prompt_eval": None,
+                "bias_report": None,
+                "model_summary": None,
+            }
+        )
+
+        self.assertIn("Status: `passed`", markdown)
+        self.assertIn("Training was skipped", markdown)
+
+    def test_build_summary_loads_neighbor_reports(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            manifest_path = root / "manifest.json"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "status": "passed",
+                        "generated_at_utc": "2026-01-01T00:00:00Z",
+                        "steps": [{"name": "evaluate_prompts", "artifacts": []}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "prompt_evaluation.json").write_text(
+                json.dumps({"summary": {"records": 2, "average_score": 3.5, "grades": {"strong": 2}}}),
+                encoding="utf-8",
+            )
+
+            summary = summarize_lab_run.build_summary(manifest_path)
+
+        self.assertEqual(summary["prompt_eval"]["summary"]["records"], 2)
+
+    def test_artifact_path_finds_matching_suffix(self):
+        path = summarize_lab_run.artifact_path(
+            {"artifacts": [{"path": "outputs/lab_run/prompt_evaluation.json"}]},
+            "prompt_evaluation.json",
+        )
+
+        self.assertEqual(path, Path("outputs/lab_run/prompt_evaluation.json"))


### PR DESCRIPTION
## Summary
- add a Markdown summary generator for completed lab runs
- summarize workflow status, prompt evaluation, bias review, and sentiment baseline metrics
- document how to create the report from the lab-run manifest

## Verification
- python3 scripts/run_lab_workflow.py --output-dir outputs/lab_run
- python3 scripts/summarize_lab_run.py --manifest outputs/lab_run/manifest.json --output outputs/lab_run/summary.md
- python3 scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training
- python3 scripts/summarize_lab_run.py --manifest outputs/ci_lab_run/manifest.json --output outputs/ci_lab_run/summary.md
- python3 -m unittest discover -s tests -v