### PR TITLE
Add sample dataset catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ python scripts/train_model.py \
 ```
 
 For one compact path through prompt generation, bias review, and sentiment training, see [docs/lab_walkthrough.md](docs/lab_walkthrough.md).
+For sample dataset schemas, row counts, and fingerprints, see [docs/dataset_catalog.md](docs/dataset_catalog.md).
 For prompt-batch scoring guidance, see [docs/prompt_evaluation.md](docs/prompt_evaluation.md).
 For the training data contract, run metadata, and baseline limitations, see [docs/model_baseline.md](docs/model_baseline.md).
 

--- a/docs/dataset_catalog.md
+++ b/docs/dataset_catalog.md
@@ -1,0 +1,21 @@
+# Dataset Catalog
+
+This catalog documents the bundled sample datasets used by the local lab workflow.
+
+| Dataset | Format | Rows | Columns | SHA-256 |
+|---|---|---:|---|---|
+| `datasets/sample_bias_texts.csv` | csv | 8 | id, group, text | `4ea67fc63b714cc49abe21a8ceae97151e2b14c788b1b44d8592452d85b85a51` |
+| `datasets/sample_prompts.csv` | csv | 5 | topic | `0b28654867556d96818ca70babb362b9c1cf4576aa94cbf3583ac10e3503f64e` |
+| `datasets/sentiment_training.json` | json | 40 | text, label | `f336fe041e430866fab8f3197c2e5c23b91f1cf691ac807565e833ed313a9626` |
+
+## Dataset Notes
+
+- All bundled datasets are synthetic or instructional samples.
+- They are intended for workflow demonstration and validation, not production modeling.
+- Hashes help reviewers confirm which dataset version produced a lab run.
+
+### `datasets/sentiment_training.json`
+
+- Description: Balanced dataset of short text reviews labeled for sentiment classification. Labels: 1=Positive, 0=Negative.
+- Classes: `{'0': 'negative', '1': 'positive'}`
+- Label counts: `{'0': 20, '1': 20}`

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -116,3 +116,5 @@ python -m unittest discover -s tests -v
 - responsible-AI review with traceable flagged rows and group metrics
 - a reproducible baseline training run with saved artifacts
 - a small local validation loop suitable for pull requests
+
+The bundled sample datasets are documented in `docs/dataset_catalog.md`.

--- a/scripts/catalog_datasets.py
+++ b/scripts/catalog_datasets.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Generate a lightweight datasheet-style catalog for bundled sample datasets.
+"""
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def sha256_file(path: Path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def catalog_csv(path: Path):
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+    return {
+        "path": str(path),
+        "format": "csv",
+        "sha256": sha256_file(path),
+        "rows": len(rows),
+        "columns": reader.fieldnames or [],
+    }
+
+
+def catalog_sentiment_json(path: Path):
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    labels = payload.get("label", [])
+    texts = payload.get("text", [])
+    return {
+        "path": str(path),
+        "format": "json",
+        "sha256": sha256_file(path),
+        "rows": len(texts),
+        "columns": ["text", "label"],
+        "description": payload.get("description"),
+        "classes": payload.get("classes", {}),
+        "label_counts": {str(label): count for label, count in sorted(Counter(labels).items())},
+    }
+
+
+def catalog_dataset(path: Path):
+    if path.suffix.lower() == ".csv":
+        return catalog_csv(path)
+    if path.name == "sentiment_training.json":
+        return catalog_sentiment_json(path)
+    raise ValueError(f"Unsupported dataset format: {path}")
+
+
+def build_catalog(dataset_dir: Path):
+    paths = sorted(
+        path for path in dataset_dir.iterdir()
+        if path.is_file() and path.suffix.lower() in {".csv", ".json"}
+    )
+    return [catalog_dataset(path) for path in paths]
+
+
+def render_markdown(catalog: list[dict]):
+    lines = [
+        "# Dataset Catalog",
+        "",
+        "This catalog documents the bundled sample datasets used by the local lab workflow.",
+        "",
+        "| Dataset | Format | Rows | Columns | SHA-256 |",
+        "|---|---|---:|---|---|",
+    ]
+    for item in catalog:
+        columns = ", ".join(item["columns"])
+        lines.append(f"| `{item['path']}` | {item['format']} | {item['rows']} | {columns} | `{item['sha256']}` |")
+
+    lines += [
+        "",
+        "## Dataset Notes",
+        "",
+        "- All bundled datasets are synthetic or instructional samples.",
+        "- They are intended for workflow demonstration and validation, not production modeling.",
+        "- Hashes help reviewers confirm which dataset version produced a lab run.",
+    ]
+
+    for item in catalog:
+        if item.get("label_counts"):
+            lines += [
+                "",
+                f"### `{item['path']}`",
+                "",
+                f"- Description: {item.get('description') or 'Not provided'}",
+                f"- Classes: `{item.get('classes')}`",
+                f"- Label counts: `{item['label_counts']}`",
+            ]
+
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a dataset catalog for bundled lab datasets.")
+    parser.add_argument("--dataset-dir", default="datasets", help="Directory containing sample datasets.")
+    parser.add_argument("--output", default="docs/dataset_catalog.md", help="Markdown catalog output path.")
+    args = parser.parse_args()
+
+    catalog = build_catalog(Path(args.dataset_dir))
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_markdown(catalog), encoding="utf-8")
+    print(f"Dataset catalog written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_catalog_datasets.py
+++ b/tests/test_catalog_datasets.py
@@ -1,0 +1,56 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import catalog_datasets
+
+
+class CatalogDatasetsTests(unittest.TestCase):
+    def test_catalog_csv_records_rows_and_columns(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "sample.csv"
+            path.write_text("id,text\n1,hello\n2,world\n", encoding="utf-8")
+
+            item = catalog_datasets.catalog_csv(path)
+
+        self.assertEqual(item["rows"], 2)
+        self.assertEqual(item["columns"], ["id", "text"])
+        self.assertEqual(item["format"], "csv")
+
+    def test_catalog_sentiment_json_records_label_counts(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "sentiment_training.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "description": "sample",
+                        "classes": {"0": "negative", "1": "positive"},
+                        "text": ["bad", "good", "great"],
+                        "label": [0, 1, 1],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            item = catalog_datasets.catalog_sentiment_json(path)
+
+        self.assertEqual(item["rows"], 3)
+        self.assertEqual(item["label_counts"], {"0": 1, "1": 2})
+
+    def test_render_markdown_includes_hashes_and_notes(self):
+        markdown = catalog_datasets.render_markdown(
+            [
+                {
+                    "path": "datasets/sample.csv",
+                    "format": "csv",
+                    "rows": 1,
+                    "columns": ["text"],
+                    "sha256": "abc123",
+                }
+            ]
+        )
+
+        self.assertIn("# Dataset Catalog", markdown)
+        self.assertIn("abc123", markdown)
+        self.assertIn("synthetic or instructional", markdown)


### PR DESCRIPTION
## Summary
- add a dataset catalog generator for bundled sample CSV and JSON datasets
- commit a generated catalog with schemas, row counts, label counts, and SHA-256 fingerprints
- link the catalog from the README and guided lab walkthrough

## Verification
- python3 scripts/catalog_datasets.py --dataset-dir datasets --output docs/dataset_catalog.md
- python3 -m unittest discover -s tests -v
- python3 scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training