### PR TITLE
Check dataset catalog freshness

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -32,5 +32,8 @@ jobs:
       - name: Run unit tests
         run: python -m unittest discover -s tests -v
 
+      - name: Check dataset catalog freshness
+        run: python scripts/catalog_datasets.py --dataset-dir datasets --output docs/dataset_catalog.md --check
+
       - name: Run lab smoke test
         run: python scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -118,3 +118,11 @@ python -m unittest discover -s tests -v
 - a small local validation loop suitable for pull requests
 
 The bundled sample datasets are documented in `docs/dataset_catalog.md`.
+Check that the catalog matches the current dataset files with:
+
+```bash
+python scripts/catalog_datasets.py \
+  --dataset-dir datasets \
+  --output docs/dataset_catalog.md \
+  --check
+```

--- a/scripts/catalog_datasets.py
+++ b/scripts/catalog_datasets.py
@@ -100,12 +100,24 @@ def main():
     parser = argparse.ArgumentParser(description="Generate a dataset catalog for bundled lab datasets.")
     parser.add_argument("--dataset-dir", default="datasets", help="Directory containing sample datasets.")
     parser.add_argument("--output", default="docs/dataset_catalog.md", help="Markdown catalog output path.")
+    parser.add_argument("--check", action="store_true", help="Fail if the existing catalog is stale.")
     args = parser.parse_args()
 
     catalog = build_catalog(Path(args.dataset_dir))
     output_path = Path(args.output)
+    rendered = render_markdown(catalog)
+
+    if args.check:
+        if not output_path.exists():
+            raise SystemExit(f"Dataset catalog is missing: {output_path}")
+        current = output_path.read_text(encoding="utf-8")
+        if current != rendered:
+            raise SystemExit(f"Dataset catalog is stale: {output_path}. Regenerate it before committing.")
+        print(f"Dataset catalog is up to date: {output_path}")
+        return
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(render_markdown(catalog), encoding="utf-8")
+    output_path.write_text(rendered, encoding="utf-8")
     print(f"Dataset catalog written to {output_path}")
 
 

--- a/tests/test_catalog_datasets.py
+++ b/tests/test_catalog_datasets.py
@@ -54,3 +54,10 @@ class CatalogDatasetsTests(unittest.TestCase):
         self.assertIn("# Dataset Catalog", markdown)
         self.assertIn("abc123", markdown)
         self.assertIn("synthetic or instructional", markdown)
+
+    def test_catalog_check_accepts_current_committed_catalog(self):
+        catalog = catalog_datasets.build_catalog(Path("datasets"))
+        rendered = catalog_datasets.render_markdown(catalog)
+        current = Path("docs/dataset_catalog.md").read_text(encoding="utf-8")
+
+        self.assertEqual(current, rendered)


### PR DESCRIPTION
## Summary
- add a --check mode to the dataset catalog generator
- verify the committed dataset catalog matches the current sample datasets in CI
- document the freshness check in the guided walkthrough

## Verification
- python3 -m unittest discover -s tests -v
- python3 scripts/catalog_datasets.py --dataset-dir datasets --output docs/dataset_catalog.md --check
- python3 scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training