### PR TITLE
Add sentiment model card generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ python scripts/summarize_lab_run.py \
   --manifest outputs/lab_run/manifest.json \
   --output outputs/lab_run/summary.md
 
+# Generate a model card from a completed training run
+python scripts/generate_model_card.py \
+  --summary outputs/lab_run/sentiment_model_summary.json \
+  --output outputs/lab_run/sentiment_model_card.md
+
 # Generate prompt variants from the sample topic list
 python scripts/generate_prompts.py \
   --input datasets/sample_prompts.csv \

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -16,6 +16,7 @@ Expected result:
 - prompt evaluation report
 - bias review report
 - sentiment baseline model and summary
+- sentiment baseline model card
 - `outputs/lab_run/manifest.json`
 
 The manifest records each step, captured command output, and whether every expected artifact was created.
@@ -99,6 +100,7 @@ Expected result:
 
 - `outputs/sentiment_model.joblib`
 - `outputs/sentiment_model_summary.json`
+- `outputs/sentiment_model_card.md` when the full runner is used
 
 ## 5. Validate The Repo
 

--- a/docs/model_baseline.md
+++ b/docs/model_baseline.md
@@ -40,6 +40,14 @@ Each summary JSON records:
 - selected parameters
 - test metrics and confusion matrix
 
+Generate a lightweight model card from a completed training summary:
+
+```bash
+python scripts/generate_model_card.py \
+  --summary outputs/sentiment_model_summary.json \
+  --output outputs/sentiment_model_card.md
+```
+
 Run the baseline with a fixed seed:
 
 ```bash
@@ -56,4 +64,5 @@ Because the bundled dataset is deliberately small, metrics may look weak or unst
 
 - confirm the training path runs
 - inspect the saved summary
+- generate a model card for review
 - use the baseline as a comparison point for richer datasets or later models

--- a/scripts/generate_model_card.py
+++ b/scripts/generate_model_card.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Generate a lightweight model card from a training summary JSON file.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_summary(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def render_model_card(summary: dict):
+    test = summary.get("test", {})
+    splits = summary.get("splits", {})
+    artifacts = summary.get("artifacts", {})
+    lines = [
+        "# Sentiment Baseline Model Card",
+        "",
+        "## Model Details",
+        "",
+        "- Model family: `TF-IDF + Logistic Regression`",
+        f"- Run ID: `{summary.get('run_id', 'unknown')}`",
+        f"- Created: `{summary.get('timestamp_utc', 'unknown')}`",
+        f"- Model artifact: `{artifacts.get('model_path', 'unknown')}`",
+        "",
+        "## Intended Use",
+        "",
+        "This model is a small instructional baseline for the AI Engineering Lab sentiment workflow.",
+        "Use it to verify the training pipeline, inspect saved metrics, and compare later experiments against a simple starting point.",
+        "",
+        "## Data",
+        "",
+        f"- Source: `{summary.get('data_path', 'unknown')}`",
+        f"- SHA-256: `{summary.get('data_sha256', 'unknown')}`",
+        f"- Rows: `{summary.get('rows', 'unknown')}`",
+        f"- Class distribution: `{summary.get('class_dist', {})}`",
+        f"- Split sizes: train `{splits.get('train', 0)}`, validation `{splits.get('val', 0)}`, test `{splits.get('test', 0)}`",
+        "",
+        "## Evaluation",
+        "",
+        f"- Test ROC-AUC: `{test.get('roc_auc')}`",
+        f"- Confusion matrix: `{test.get('confusion_matrix')}`",
+        "",
+        "## Limitations",
+        "",
+        "- The bundled dataset is intentionally tiny and synthetic.",
+        "- Metrics are useful for workflow validation, not production performance claims.",
+        "- The model should not be deployed for real sentiment decisions without larger representative data and additional evaluation.",
+        "",
+        "## Responsible AI Notes",
+        "",
+        "- Treat outputs as experimental.",
+        "- Review dataset provenance before replacing the sample data.",
+        "- Compare future models against this baseline using consistent splits and documented run summaries.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate a model card from a sentiment training summary.")
+    parser.add_argument("--summary", required=True, help="Path to sentiment_model_summary.json")
+    parser.add_argument("--output", required=True, help="Markdown model-card output path")
+    args = parser.parse_args()
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_model_card(load_summary(Path(args.summary))), encoding="utf-8")
+    print(f"Model card written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_lab_workflow.py
+++ b/scripts/run_lab_workflow.py
@@ -24,6 +24,7 @@ def build_steps(python_executable: str, output_dir: Path, skip_training: bool = 
     bias_base = output_dir / "sample_bias_report"
     model_path = output_dir / "sentiment_model.joblib"
     summary_path = output_dir / "sentiment_model_summary.json"
+    model_card_path = output_dir / "sentiment_model_card.md"
 
     steps = [
         {
@@ -91,6 +92,20 @@ def build_steps(python_executable: str, output_dir: Path, skip_training: bool = 
                     "42",
                 ],
                 "artifacts": [model_path, summary_path],
+            }
+        )
+        steps.append(
+            {
+                "name": "generate_model_card",
+                "command": [
+                    python_executable,
+                    "scripts/generate_model_card.py",
+                    "--summary",
+                    str(summary_path),
+                    "--output",
+                    str(model_card_path),
+                ],
+                "artifacts": [model_card_path],
             }
         )
 

--- a/tests/test_generate_model_card.py
+++ b/tests/test_generate_model_card.py
@@ -1,0 +1,25 @@
+import unittest
+
+from scripts import generate_model_card
+
+
+class GenerateModelCardTests(unittest.TestCase):
+    def test_render_model_card_includes_required_sections(self):
+        markdown = generate_model_card.render_model_card(
+            {
+                "run_id": "run-123",
+                "timestamp_utc": "2026-01-01T00:00:00Z",
+                "data_path": "datasets/sentiment_training.json",
+                "data_sha256": "abc123",
+                "rows": 40,
+                "class_dist": {"0": 20, "1": 20},
+                "splits": {"train": 32, "val": 0, "test": 8},
+                "test": {"roc_auc": 0.5, "confusion_matrix": [[2, 2], [2, 2]]},
+                "artifacts": {"model_path": "outputs/sentiment_model.joblib"},
+            }
+        )
+
+        self.assertIn("# Sentiment Baseline Model Card", markdown)
+        self.assertIn("## Intended Use", markdown)
+        self.assertIn("abc123", markdown)
+        self.assertIn("## Limitations", markdown)

--- a/tests/test_run_lab_workflow.py
+++ b/tests/test_run_lab_workflow.py
@@ -15,6 +15,7 @@ class RunLabWorkflowTests(unittest.TestCase):
             "evaluate_prompts",
             "bias_detection",
             "train_sentiment_baseline",
+            "generate_model_card",
         ])
         self.assertIn(Path("outputs/lab_run/generated_prompts.json"), steps[0]["artifacts"])
 
@@ -22,6 +23,7 @@ class RunLabWorkflowTests(unittest.TestCase):
         steps = run_lab_workflow.build_steps("python", Path("outputs/lab_run"), skip_training=True)
 
         self.assertNotIn("train_sentiment_baseline", [step["name"] for step in steps])
+        self.assertNotIn("generate_model_card", [step["name"] for step in steps])
 
     def test_write_manifest_records_steps(self):
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- add a model-card generator for sentiment training summaries
- wire model-card generation into the full local lab workflow
- document model-card creation in the README, lab walkthrough, and baseline guide

## Verification
- python3 scripts/run_lab_workflow.py --output-dir outputs/lab_run
- python3 scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training
- python3 -m unittest discover -s tests -v