### PR TITLE
Add lightweight notebook validation

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -35,5 +35,8 @@ jobs:
       - name: Check dataset catalog freshness
         run: python scripts/catalog_datasets.py --dataset-dir datasets --output docs/dataset_catalog.md --check
 
+      - name: Validate notebooks
+        run: python scripts/validate_notebooks.py --notebook-dir notebooks
+
       - name: Run lab smoke test
         run: python scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Run the built-in test suite before changing scripts:
 ```bash
 pip install -r requirements-test.txt
 python -m unittest discover -s tests -v
+python scripts/validate_notebooks.py --notebook-dir notebooks
 ```
 
 ---

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -109,6 +109,7 @@ Run the lightweight regression suite before changing scripts:
 ```bash
 pip install -r requirements-test.txt
 python -m unittest discover -s tests -v
+python scripts/validate_notebooks.py --notebook-dir notebooks
 ```
 
 ## What This Demonstrates

--- a/scripts/validate_notebooks.py
+++ b/scripts/validate_notebooks.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Validate notebook structure and Python code-cell syntax without executing cells.
+"""
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+
+def validate_notebook(path: Path):
+    try:
+        notebook = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid notebook JSON: {exc}") from exc
+
+    cells = notebook.get("cells")
+    if not isinstance(cells, list):
+        raise ValueError(f"{path}: notebook must contain a cells list.")
+
+    code_cells = 0
+    markdown_cells = 0
+    for index, cell in enumerate(cells, start=1):
+        cell_type = cell.get("cell_type")
+        source = "".join(cell.get("source", []))
+        if cell_type == "code":
+            code_cells += 1
+            try:
+                ast.parse(source)
+            except SyntaxError as exc:
+                raise ValueError(f"{path}: code cell {index} has invalid Python syntax: {exc}") from exc
+        elif cell_type == "markdown":
+            markdown_cells += 1
+
+    if code_cells == 0:
+        raise ValueError(f"{path}: notebook must contain at least one code cell.")
+    if markdown_cells == 0:
+        raise ValueError(f"{path}: notebook must contain at least one markdown cell.")
+
+    return {
+        "path": str(path),
+        "code_cells": code_cells,
+        "markdown_cells": markdown_cells,
+    }
+
+
+def validate_directory(path: Path):
+    notebooks = sorted(path.glob("*.ipynb"))
+    if not notebooks:
+        raise ValueError(f"No notebooks found in {path}.")
+    return [validate_notebook(notebook) for notebook in notebooks]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate notebook JSON and code-cell syntax.")
+    parser.add_argument("--notebook-dir", default="notebooks", help="Directory containing .ipynb files.")
+    args = parser.parse_args()
+
+    results = validate_directory(Path(args.notebook_dir))
+    for result in results:
+        print(
+            f"Validated {result['path']}: "
+            f"{result['code_cells']} code cell(s), {result['markdown_cells']} markdown cell(s)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_validate_notebooks.py
+++ b/tests/test_validate_notebooks.py
@@ -1,0 +1,52 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import validate_notebooks
+
+
+class ValidateNotebooksTests(unittest.TestCase):
+    def test_validate_notebook_accepts_markdown_and_code_cells(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            notebook = Path(tmp_dir) / "sample.ipynb"
+            notebook.write_text(
+                json.dumps(
+                    {
+                        "cells": [
+                            {"cell_type": "markdown", "source": ["# Demo"]},
+                            {"cell_type": "code", "source": ["x = 1\n", "print(x)"]},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = validate_notebooks.validate_notebook(notebook)
+
+        self.assertEqual(result["code_cells"], 1)
+        self.assertEqual(result["markdown_cells"], 1)
+
+    def test_validate_notebook_rejects_invalid_code_syntax(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            notebook = Path(tmp_dir) / "broken.ipynb"
+            notebook.write_text(
+                json.dumps(
+                    {
+                        "cells": [
+                            {"cell_type": "markdown", "source": ["# Demo"]},
+                            {"cell_type": "code", "source": ["def broken(:\n", "    pass"]},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "invalid Python syntax"):
+                validate_notebooks.validate_notebook(notebook)
+
+    def test_validate_directory_checks_committed_notebooks(self):
+        results = validate_notebooks.validate_directory(Path("notebooks"))
+
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all(result["code_cells"] > 0 for result in results))


### PR DESCRIPTION
## Summary
- add a notebook validator that checks .ipynb JSON shape and Python code-cell syntax without executing notebooks
- wire notebook validation into CI after unit tests and dataset catalog checks
- document notebook validation in the README and guided walkthrough

## Verification
- python3 -m unittest discover -s tests -v
- python3 scripts/catalog_datasets.py --dataset-dir datasets --output docs/dataset_catalog.md --check
- python3 scripts/validate_notebooks.py --notebook-dir notebooks
- python3 scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training