### PR TITLE
Add repository validation runner

### DIFF
--- a/.github/workflows/python-validation.yml
+++ b/.github/workflows/python-validation.yml
@@ -30,13 +30,7 @@ jobs:
           pip install -r requirements-test.txt
 
       - name: Run unit tests
-        run: python -m unittest discover -s tests -v
-
-      - name: Check dataset catalog freshness
-        run: python scripts/catalog_datasets.py --dataset-dir datasets --output docs/dataset_catalog.md --check
-
-      - name: Validate notebooks
-        run: python scripts/validate_notebooks.py --notebook-dir notebooks
+        run: python scripts/validate_repo.py --skip-lab
 
       - name: Run lab smoke test
         run: python scripts/run_lab_workflow.py --output-dir outputs/ci_lab_run --skip-training

--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ Run the built-in test suite before changing scripts:
 
 ```bash
 pip install -r requirements-test.txt
-python -m unittest discover -s tests -v
-python scripts/validate_notebooks.py --notebook-dir notebooks
+python scripts/validate_repo.py
 ```
 
 ---

--- a/docs/lab_walkthrough.md
+++ b/docs/lab_walkthrough.md
@@ -108,8 +108,7 @@ Run the lightweight regression suite before changing scripts:
 
 ```bash
 pip install -r requirements-test.txt
-python -m unittest discover -s tests -v
-python scripts/validate_notebooks.py --notebook-dir notebooks
+python scripts/validate_repo.py
 ```
 
 ## What This Demonstrates

--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Run the repository's local validation checks in the same order as CI.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+def repo_root():
+    return Path(__file__).resolve().parents[1]
+
+
+def build_checks(python_executable: str, include_lab: bool = True):
+    checks = [
+        {
+            "name": "unit_tests",
+            "command": [python_executable, "-m", "unittest", "discover", "-s", "tests", "-v"],
+        },
+        {
+            "name": "dataset_catalog",
+            "command": [
+                python_executable,
+                "scripts/catalog_datasets.py",
+                "--dataset-dir",
+                "datasets",
+                "--output",
+                "docs/dataset_catalog.md",
+                "--check",
+            ],
+        },
+        {
+            "name": "notebooks",
+            "command": [
+                python_executable,
+                "scripts/validate_notebooks.py",
+                "--notebook-dir",
+                "notebooks",
+            ],
+        },
+    ]
+
+    if include_lab:
+        checks.append(
+            {
+                "name": "lab_smoke",
+                "command": [
+                    python_executable,
+                    "scripts/run_lab_workflow.py",
+                    "--output-dir",
+                    "outputs/ci_lab_run",
+                    "--skip-training",
+                ],
+            }
+        )
+
+    return checks
+
+
+def run_check(check: dict, root: Path):
+    print(f"Running {check['name']}...", flush=True)
+    subprocess.run(check["command"], cwd=root, check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run AI Engineering Lab validation checks.")
+    parser.add_argument("--skip-lab", action="store_true", help="Skip the integrated lab smoke test.")
+    args = parser.parse_args()
+
+    root = repo_root()
+    for check in build_checks(sys.executable, include_lab=not args.skip_lab):
+        run_check(check, root)
+
+    print("Repository validation passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -1,0 +1,21 @@
+import unittest
+
+from scripts import validate_repo
+
+
+class ValidateRepoTests(unittest.TestCase):
+    def test_build_checks_matches_expected_order(self):
+        checks = validate_repo.build_checks("python")
+
+        self.assertEqual(
+            [check["name"] for check in checks],
+            ["unit_tests", "dataset_catalog", "notebooks", "lab_smoke"],
+        )
+
+    def test_build_checks_can_skip_lab_smoke_test(self):
+        checks = validate_repo.build_checks("python", include_lab=False)
+
+        self.assertEqual(
+            [check["name"] for check in checks],
+            ["unit_tests", "dataset_catalog", "notebooks"],
+        )


### PR DESCRIPTION
## Summary
- add a one-command validation runner that executes unit tests, dataset catalog freshness, notebook syntax validation, and optional lab smoke testing
- update CI to reuse the validation runner before the separate lab smoke step
- simplify README and walkthrough validation guidance to the single command

## Verification
- python3 scripts/validate_repo.py
- python3 scripts/validate_repo.py --skip-lab