### PR TITLE
Add prompt evaluation feedback

### DIFF
--- a/docs/prompt_evaluation.md
+++ b/docs/prompt_evaluation.md
@@ -46,10 +46,13 @@ Outputs:
 - `outputs/prompt_evaluation.json`
 - `outputs/prompt_evaluation.md`
 
+Reports include grade distribution, rubric coverage percentages, top prompts, and a short `Needs Attention` section with recommendations for prompts that missed one or more rubric dimensions.
+
 ## How To Use It
 
 - compare batches after changing templates
 - spot prompt families that are consistently thin
+- review missing-dimension recommendations before editing templates
 - keep prompt experiments reviewable before involving an LLM API
 
 This is a heuristic quality screen, not a substitute for task-grounded evaluation against real model outputs.

--- a/scripts/evaluate_prompts.py
+++ b/scripts/evaluate_prompts.py
@@ -14,6 +14,12 @@ from pathlib import Path
 
 STRUCTURE_TERMS = ("checklist", "bullets", "sections", "outline", "matrix", "step-by-step")
 EVALUATION_TERMS = ("criteria", "metrics", "assessment", "risks", "pitfalls", "mitigations")
+DIMENSION_GUIDANCE = {
+    "specificity": "Add concrete constraints such as an exact count, required sections, or explicit inclusions.",
+    "structure": "Ask for a clear output structure such as a checklist, bullets, sections, outline, or matrix.",
+    "audience": "Name the target audience so the response can tune depth, tone, and examples.",
+    "evaluation_ready": "Request criteria, metrics, risks, assessment questions, pitfalls, or mitigations.",
+}
 
 
 def load_prompt_records(path: Path):
@@ -42,21 +48,36 @@ def score_prompt(record: dict):
         "evaluation_ready": int(any(token in lower for token in EVALUATION_TERMS)),
     }
     total = sum(dimensions.values())
+    recommendations = [
+        DIMENSION_GUIDANCE[name]
+        for name, passed in dimensions.items()
+        if not passed
+    ]
     return {
         **record,
         "rubric": dimensions,
         "score": total,
         "grade": "strong" if total >= 3 else "usable" if total >= 2 else "thin",
+        "recommendations": recommendations,
     }
 
 
 def summarize(scored_records):
     by_grade = Counter(record["grade"] for record in scored_records)
     avg_score = round(sum(record["score"] for record in scored_records) / max(1, len(scored_records)), 3)
+    total_records = max(1, len(scored_records))
+    rubric_coverage = {
+        dimension: round(
+            sum(record["rubric"][dimension] for record in scored_records) / total_records,
+            3,
+        )
+        for dimension in DIMENSION_GUIDANCE
+    }
     return {
         "records": len(scored_records),
         "average_score": avg_score,
         "grades": dict(sorted(by_grade.items())),
+        "rubric_coverage": rubric_coverage,
         "top_prompts": [
             {
                 "topic": record.get("topic"),
@@ -65,6 +86,17 @@ def summarize(scored_records):
                 "grade": record["grade"],
             }
             for record in sorted(scored_records, key=lambda row: (-row["score"], row["prompt"]))[:5]
+        ],
+        "needs_attention": [
+            {
+                "topic": record.get("topic"),
+                "prompt": record["prompt"],
+                "score": record["score"],
+                "grade": record["grade"],
+                "recommendations": record["recommendations"],
+            }
+            for record in sorted(scored_records, key=lambda row: (row["score"], row["prompt"]))[:5]
+            if record["recommendations"]
         ],
     }
 
@@ -84,10 +116,21 @@ def write_markdown(path: Path, summary: dict):
     for grade, count in summary["grades"].items():
         lines.append(f"| {grade} | {count} |")
 
+    lines += ["", "## Rubric Coverage", "", "| Dimension | Coverage |", "|---|---:|"]
+    for dimension, coverage in summary["rubric_coverage"].items():
+        lines.append(f"| {dimension.replace('_', ' ').title()} | {coverage:.1%} |")
+
     lines += ["", "## Top Prompts", ""]
     for record in summary["top_prompts"]:
         topic = record["topic"] or "Unlabeled"
         lines.append(f"- **{topic}** (`{record['score']}` / {record['grade']}): {record['prompt']}")
+
+    if summary["needs_attention"]:
+        lines += ["", "## Needs Attention", ""]
+        for record in summary["needs_attention"]:
+            topic = record["topic"] or "Unlabeled"
+            recommendation = " ".join(record["recommendations"])
+            lines.append(f"- **{topic}** (`{record['score']}` / {record['grade']}): {recommendation}")
 
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 

--- a/tests/test_evaluate_prompts.py
+++ b/tests/test_evaluate_prompts.py
@@ -30,16 +30,67 @@ class EvaluatePromptsTests(unittest.TestCase):
 
         self.assertEqual(scored["score"], 4)
         self.assertEqual(scored["grade"], "strong")
+        self.assertEqual(scored["recommendations"], [])
+
+    def test_score_prompt_recommends_missing_dimensions(self):
+        scored = evaluate_prompts.score_prompt({"prompt": "Explain caching."})
+
+        self.assertEqual(scored["grade"], "thin")
+        self.assertEqual(len(scored["recommendations"]), 4)
+        self.assertIn("Name the target audience", scored["recommendations"][2])
 
     def test_summarize_reports_grade_distribution(self):
         summary = evaluate_prompts.summarize(
             [
-                {"prompt": "a", "score": 4, "grade": "strong"},
-                {"prompt": "b", "score": 2, "grade": "usable"},
-                {"prompt": "c", "score": 1, "grade": "thin"},
+                {
+                    "prompt": "a",
+                    "score": 4,
+                    "grade": "strong",
+                    "rubric": {"specificity": 1, "structure": 1, "audience": 1, "evaluation_ready": 1},
+                    "recommendations": [],
+                },
+                {
+                    "prompt": "b",
+                    "score": 2,
+                    "grade": "usable",
+                    "rubric": {"specificity": 1, "structure": 1, "audience": 0, "evaluation_ready": 0},
+                    "recommendations": ["Name the target audience."],
+                },
+                {
+                    "prompt": "c",
+                    "score": 1,
+                    "grade": "thin",
+                    "rubric": {"specificity": 1, "structure": 0, "audience": 0, "evaluation_ready": 0},
+                    "recommendations": ["Ask for a clear output structure."],
+                },
             ]
         )
 
         self.assertEqual(summary["records"], 3)
         self.assertEqual(summary["average_score"], 2.333)
         self.assertEqual(summary["grades"], {"strong": 1, "thin": 1, "usable": 1})
+        self.assertEqual(summary["rubric_coverage"]["specificity"], 1.0)
+        self.assertEqual(summary["rubric_coverage"]["evaluation_ready"], 0.333)
+        self.assertEqual(summary["needs_attention"][0]["prompt"], "c")
+
+    def test_write_markdown_includes_recommendations(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            report_path = Path(tmp_dir) / "report.md"
+            summary = evaluate_prompts.summarize(
+                [
+                    evaluate_prompts.score_prompt({"prompt": "Explain caching.", "topic": "Caching"}),
+                    evaluate_prompts.score_prompt(
+                        {
+                            "prompt": "Create a checklist for a junior dev. Include metrics.",
+                            "topic": "Caching",
+                        }
+                    ),
+                ]
+            )
+
+            evaluate_prompts.write_markdown(report_path, summary)
+            report = report_path.read_text(encoding="utf-8")
+
+        self.assertIn("## Rubric Coverage", report)
+        self.assertIn("## Needs Attention", report)
+        self.assertIn("Name the target audience", report)


### PR DESCRIPTION
## Summary
- Add missing-dimension recommendations to each scored prompt
- Add rubric coverage and Needs Attention sections to Markdown reports
- Cover the new feedback path with evaluator tests and docs

## Validation
- python3 -m unittest tests.test_evaluate_prompts
- python3 scripts/generate_prompts.py --input datasets/sample_prompts.csv --output /tmp/generated_prompts.json --with-metadata --dedupe --seed 42
- python3 scripts/evaluate_prompts.py --input /tmp/generated_prompts.json --output-base /tmp/prompt_evaluation
- python3 scripts/validate_repo.py