### PR TITLE
Add lab workflow dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Run the command-line experiments directly:
 # Run the full no-API lab workflow
 python scripts/run_lab_workflow.py --output-dir outputs/lab_run
 
+# Preview workflow commands and artifacts without running them
+python scripts/run_lab_workflow.py --output-dir outputs/lab_run --dry-run
+
 # Summarize the completed run
 python scripts/summarize_lab_run.py \
   --manifest outputs/lab_run/manifest.json \

--- a/scripts/run_lab_workflow.py
+++ b/scripts/run_lab_workflow.py
@@ -151,6 +151,28 @@ def validate_artifacts(paths: list[Path]):
     return artifacts
 
 
+def build_plan(steps: list[dict]):
+    return [
+        {
+            "name": step["name"],
+            "command": step["command"],
+            "artifacts": [str(path) for path in step["artifacts"]],
+        }
+        for step in steps
+    ]
+
+
+def print_plan(plan: list[dict]):
+    print("Lab workflow dry run. Planned steps:")
+    for index, step in enumerate(plan, start=1):
+        print(f"{index}. {step['name']}")
+        print(f"   command: {' '.join(step['command'])}")
+        if step["artifacts"]:
+            print("   artifacts:")
+            for artifact in step["artifacts"]:
+                print(f"   - {artifact}")
+
+
 def write_manifest(path: Path, results: list[dict]):
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -167,12 +189,17 @@ def main():
     parser.add_argument("--output-dir", default="outputs/lab_run", help="Directory for workflow artifacts.")
     parser.add_argument("--manifest", default=None, help="Path to write the run manifest JSON.")
     parser.add_argument("--skip-training", action="store_true", help="Run prompt and bias steps without model training.")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned steps and artifacts without running commands.")
     args = parser.parse_args()
 
     root = repo_root()
     output_dir = Path(args.output_dir)
     manifest_path = Path(args.manifest) if args.manifest else output_dir / "manifest.json"
     steps = build_steps(sys.executable, output_dir, skip_training=args.skip_training)
+
+    if args.dry_run:
+        print_plan(build_plan(steps))
+        return
 
     results = []
     for step in steps:

--- a/tests/test_run_lab_workflow.py
+++ b/tests/test_run_lab_workflow.py
@@ -1,7 +1,9 @@
 import json
 import tempfile
 import unittest
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 from scripts import run_lab_workflow
 
@@ -56,3 +58,29 @@ class RunLabWorkflowTests(unittest.TestCase):
 
             with self.assertRaisesRegex(FileNotFoundError, "Expected artifact"):
                 run_lab_workflow.validate_artifacts([missing])
+
+    def test_build_plan_serializes_commands_and_artifacts(self):
+        steps = run_lab_workflow.build_steps("python", Path("outputs/lab_run"), skip_training=True)
+
+        plan = run_lab_workflow.build_plan(steps)
+
+        self.assertEqual(plan[0]["name"], "generate_prompts")
+        self.assertEqual(plan[0]["command"][0], "python")
+        self.assertIn("outputs/lab_run/generated_prompts.json", plan[0]["artifacts"])
+
+    def test_print_plan_lists_commands_and_artifacts(self):
+        plan = [
+            {
+                "name": "generate_prompts",
+                "command": ["python", "scripts/generate_prompts.py"],
+                "artifacts": ["outputs/lab_run/generated_prompts.json"],
+            }
+        ]
+
+        with patch("sys.stdout", new_callable=StringIO) as stdout:
+            run_lab_workflow.print_plan(plan)
+
+        output = stdout.getvalue()
+        self.assertIn("Lab workflow dry run", output)
+        self.assertIn("command: python scripts/generate_prompts.py", output)
+        self.assertIn("outputs/lab_run/generated_prompts.json", output)


### PR DESCRIPTION
## Summary
- Add a --dry-run mode to preview lab workflow commands and expected artifacts
- Add plan rendering helpers with focused tests
- Document the dry-run command in the README quickstart

## Validation
- python3 -m unittest tests.test_run_lab_workflow
- python3 scripts/run_lab_workflow.py --output-dir outputs/lab_run --skip-training --dry-run
- python3 scripts/validate_repo.py